### PR TITLE
feat: Configure project for Vercel deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM aisheets/sheets:dev
 
-# Set data dir under persisted volume (if enabled)
-ENV DATA_DIR /data/sheets
+# Set data dir for Vercel's ephemeral filesystem
+ENV DATA_DIR /tmp/sheets
 
-# Configure HF cache to the persisted volume
-ENV HF_HOME /data/hf_cache
+# Configure HF cache for Vercel's ephemeral filesystem
+ENV HF_HOME /tmp/hf_cache
 
 # Available environment variables
 #
@@ -14,5 +14,4 @@ ENV HF_HOME /data/hf_cache
 # Uncomment the next line if you want to change the number of concurrent requests when generating data
 # ENV NUM_CONCURRENT_REQUESTS=5
 
-# Grant write access to the node app
-RUN mkdir /data && chown -R node:node /data
+# The /tmp directory is used for data storage and should be writable by default.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,7 @@
----
-title: Sheets
-emoji: 🗂️
-colorFrom: yellow
-colorTo: red
-sdk: docker
-app_port: 3000
-fullWidth: true
-suggested_storage: small
-hf_oauth: true
-hf_oauth_scopes:
-- manage-repos
-- inference-api
----
+# AI Sheets
+
+This is a project configured for deployment on Vercel.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fpath-to-your-repo)
+
+To deploy your own instance, click the button above and follow the instructions on Vercel.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-sheets",
+  "builds": [
+    {
+      "src": "Dockerfile",
+      "use": "@vercel/docker",
+      "config": {
+        "port": 3000
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This commit makes the necessary changes to deploy the application to Vercel.

- The `Dockerfile` is modified to use `/tmp` for data and cache, which is compatible with Vercel's ephemeral filesystem.
- A `vercel.json` file is added to configure the Docker deployment on Vercel, specifying the application name and port.
- The `README.md` is updated to remove Hugging Face-specific information and now includes instructions and a button for deploying to Vercel.